### PR TITLE
Apply portfolio color theme to application

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,5 +1,5 @@
 .App {
   width: 100%;
   font-family: 'Montserrat', sans-serif;
-  color: #59922E;
+  color: #FFF9B3A3;
 }

--- a/src/styles/controlPanel.css
+++ b/src/styles/controlPanel.css
@@ -1,5 +1,5 @@
 .controlPanel {
-  background-color: #658A49;
+  background-color: #59922E;
 
 }
 
@@ -14,13 +14,13 @@
 .paramInput {
 
   padding: 0.25em;
-  background-color: #bee3a9;
+  background-color: #D1E8C5;
 }
 
 .inputText {
-  color: #cadb8d;
-  background-color: #4c7128;
-  border: 1px solid #274d0d;
+  color: #0d0d0d;
+  background-color: #D1E8C5;
+  border: 1px solid #4A7D2A;
 }
 
 .button {
@@ -28,18 +28,18 @@
 }
 
 .controlPanel p {
-  color: black;
+  color: #0d0d0d;
 }
 
 .innerknob {
-  background-color: #4c7128;
+  background-color: #0d0d0d;
 }
 .innerprogress {
-  background-color: #4c7128 !important;
+  background-color: #0d0d0d !important;
 }
 
 .innerprogress * {
-    background-color: #4c7128 !important;
+    background-color: #0d0d0d !important;
 }
 
 @media (max-width: 575.98px) {
@@ -64,3 +64,109 @@
     min-width: 150px !important;
   }
 }
+
+/* Generic input[type=range] styling */
+input[type=range] {
+  -webkit-appearance: none; /* Override default look */
+  appearance: none;
+  width: 100%; /* Full-width */
+  background: transparent; /* Otherwise white in Chrome */
+}
+
+/* Webkit (Chrome, Safari, Opera, Edge Chromium) */
+input[type=range]::-webkit-slider-runnable-track {
+  background: #59922E; /* Theme accent green */
+  height: 8px;
+  border-radius: 4px;
+}
+
+input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  margin-top: -4px; /* Centers thumb on track */
+  background: #0d0d0d; /* Theme dark color */
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+/* Firefox */
+input[type=range]::-moz-range-track {
+  background: #59922E; /* Theme accent green */
+  height: 8px;
+  border-radius: 4px;
+  border: none; /* Reset Firefox default border */
+}
+
+input[type=range]::-moz-range-thumb {
+  background: #0d0d0d; /* Theme dark color */
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  border: none; /* Reset Firefox default border */
+  cursor: pointer;
+}
+
+/* IE / Edge Legacy (styling is more limited) */
+input[type=range]::-ms-track {
+  background: #59922E; /* Theme accent green */
+  height: 8px;
+  border-radius: 4px;
+  color: transparent; /* Hides the default fill */
+  border-width: 0; /* IE specific */
+}
+input[type=range]::-ms-fill-lower { /* IE specific */
+    background: #59922E;
+    border-radius: 4px;
+}
+input[type=range]::-ms-fill-upper { /* IE specific */
+    background: #59922E; /* Make sure unifill part also has same color */
+    border-radius: 4px;
+}
+input[type=range]::-ms-thumb {
+  background: #0d0d0d; /* Theme dark color */
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  border: 0;
+  margin-top: 0px; /* IE specific */
+  cursor: pointer;
+}
+
+/* React Toolbox / similar libraries - common class name patterns */
+/* These are guesses based on common patterns like 'slider---[role]---[variation]' */
+/* Or 'rc-slider-[part]' */
+
+/* General slider track */
+div[class*="slider---track---"], 
+div[class*="rc-slider-track"] {
+  background-color: #59922E !important; /* Theme accent green */
+}
+
+/* Slider progress/fill */
+div[class*="slider---progress---"],
+div[class*="rc-slider-rail"] { /* rc-slider-rail is often the underlying bar, track is the fill */
+  background-color: #4A7D2A !important; /* Darker green for fill or base */
+}
+/* If rc-slider-rail is the base, then rc-slider-track should be the accent */
+div[class*="rc-slider-track"] {
+    background-color: #59922E !important; 
+}
+
+
+/* Slider thumb */
+div[class*="slider---thumb---"], 
+div[class*="rc-slider-handle"] {
+  background-color: #0d0d0d !important; /* Theme dark color */
+  border: 2px solid #0d0d0d !important; /* Ensure visibility if needed */
+}
+
+/* Specific for React Toolbox if it uses inline styles or SVGs for knobs/thumbs */
+/* This might be harder to override without more specific selectors */
+div[class*="slider---innerknob---"] { /* If there's an inner part to the thumb */
+    background-color: #0d0d0d !important;
+}
+
+/* The existing .innerknob and .innerprogress already target some knob-like elements */
+/* We made them #0d0d0d, which is consistent for a thumb-like element */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2,8 +2,15 @@ html {
   height:100%;
 }
 body {
-  height:100%;
+  height: 100%;
   background-color: #0d0d0d;
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.02),
+    rgba(255, 255, 255, 0.02) 1px,
+    transparent 1px,
+    transparent 10px
+  );
 }
 
 #root {

--- a/src/styles/lotkaVoltera.css
+++ b/src/styles/lotkaVoltera.css
@@ -1,6 +1,6 @@
 .axis path,
 .axis line{
-  stroke: #070a56;
+  stroke: #FFF9B3A3;
   stroke-width: 2px;
   shape-rendering: crispEdges;
 }
@@ -9,7 +9,7 @@
   font-family: Optima, Futura, sans-serif;
   font-weight: bold;
   font-size: 0.75rem;
-  fill: #070a56;
+  fill: #FFF9B3A3;
 }
 
 .SVGContainer {
@@ -18,6 +18,6 @@
 }
 
 .vectorspace{
-  background-color: #DFECC9;
+  background-color: #2c2c2c;
 }
 


### PR DESCRIPTION
This commit updates the application's CSS to match the color theme of your portfolio.

Key changes include:
- Page background changed to dark gray (#0d0d0d) with a subtle pattern.
- Main text color updated to a light off-yellow (#FFF9B3A3).
- Control panel styled with a green accent (#59922E), with dark text and light green input fields.
- Knobs, progress bars, and sliders updated to use theme colors (dark and green accents), removing default browser styles where possible.
- Lotka-Volterra graph elements (axes, text, vector space) updated for visibility and consistency with the new dark theme.

Generic and common library CSS rules have been added for sliders to ensure they align with the new theme and avoid default blue styling.