### PR TITLE
Refine control panel theme and input field styles

### DIFF
--- a/src/styles/controlPanel.css
+++ b/src/styles/controlPanel.css
@@ -1,5 +1,5 @@
 .controlPanel {
-  background-color: #59922E;
+  background-color: #1a1a1a;
 
 }
 
@@ -14,13 +14,15 @@
 .paramInput {
 
   padding: 0.25em;
-  background-color: #D1E8C5;
+  background-color: #59922E;
+  border-radius: 4px;
 }
 
 .inputText {
   color: #0d0d0d;
-  background-color: #D1E8C5;
-  border: 1px solid #4A7D2A;
+  background-color: #59922E;
+  border: 1px solid #0d0d0d;
+  border-radius: 4px;
 }
 
 .button {
@@ -28,18 +30,18 @@
 }
 
 .controlPanel p {
-  color: #0d0d0d;
+  color: #FFF9B3A3;
 }
 
 .innerknob {
-  background-color: #0d0d0d;
+  background-color: #59922E;
 }
 .innerprogress {
-  background-color: #0d0d0d !important;
+  background-color: #59922E !important;
 }
 
 .innerprogress * {
-    background-color: #0d0d0d !important;
+    background-color: #59922E !important;
 }
 
 @media (max-width: 575.98px) {
@@ -147,9 +149,10 @@ div[class*="rc-slider-track"] {
 /* Slider progress/fill */
 div[class*="slider---progress---"],
 div[class*="rc-slider-rail"] { /* rc-slider-rail is often the underlying bar, track is the fill */
-  background-color: #4A7D2A !important; /* Darker green for fill or base */
+  background-color: #59922E !important; /* Theme accent green for fill or base */
 }
 /* If rc-slider-rail is the base, then rc-slider-track should be the accent */
+/* Ensuring rc-slider-track (often the fill) is also the main accent green */
 div[class*="rc-slider-track"] {
     background-color: #59922E !important; 
 }


### PR DESCRIPTION
This commit introduces further refinements to the application theme based on your feedback:

1.  **Consistent Input Field Border Radius:**
    - Input fields (`.paramInput`, `.inputText`) in the control panel now have a consistent `border-radius: 4px;` for slightly rounded corners, enhancing mobile consistency.

2.  **Inverted Control Panel Theme:**
    - The control panel (`.controlPanel`) now has a dark background (`#1a1a1a`).
    - Text within the panel is light (`#FFF9B3A3`) for readability.
    - Input fields (`.paramInput`, `.inputText`), sliders, knobs (`.innerknob`), and progress bars (`.innerprogress`) are now green-themed (using `#59922E` accent) to contrast with the dark panel.
    - Text and border colors for these green elements are dark (`#0d0d0d`) to ensure clarity.

These changes aim to improve the visual consistency and user experience of the control panel, particularly aligning with the desired dark theme aesthetic for the panel itself while making interactive elements distinct.